### PR TITLE
Add config for local database setup

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -164,6 +164,14 @@
         "@types/node": "*"
       }
     },
+    "@types/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
+      "requires": {
+        "dotenv": "*"
+      }
+    },
     "@types/express": {
       "version": "4.17.8",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
@@ -951,6 +959,11 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/server/package.json
+++ b/server/package.json
@@ -11,11 +11,13 @@
     },
     "dependencies": {
         "@types/body-parser": "^1.19.0",
+        "@types/dotenv": "^8.2.0",
         "@types/express": "^4.17.8",
         "@types/node": "^14.11.8",
         "@types/pg": "^7.14.5",
         "@types/puppeteer": "^3.0.2",
         "body-parser": "^1.19.0",
+        "dotenv": "^8.2.0",
         "express": "^4.17.1",
         "nodemon": "^2.0.4",
         "pg": "^8.4.1",

--- a/server/src/database/db.ts
+++ b/server/src/database/db.ts
@@ -1,10 +1,12 @@
 import { Pool, QueryResult } from "pg";
 import config from "./config";
+import localconfig from "./localconfig";
 
 class Database {
     private pool: Pool;
 
     constructor() {
+        // If on docker pool should take config, if on local database pool should take localconfig
         this.pool = new Pool(config);
         this.pool.on("error", (err, client) => {
             console.error("Unexpected error on idle PostgreSQL client.", err);

--- a/server/src/database/localconfig.ts
+++ b/server/src/database/localconfig.ts
@@ -1,0 +1,12 @@
+import dotenv from "dotenv";
+dotenv.config();
+
+const localconfig = {
+    user: process.env.LOCAL_USER,
+    database: process.env.LOCAL_DB,
+    password: process.env.LOCAL_PASSWORD,
+    host: process.env.LOCAL_HOST,
+    port: Number(process.env.LOCAL_PORT),
+};
+
+export default localconfig;


### PR DESCRIPTION
# Changes
If not using docker (using local db instead), current database config doesn't work. Added another config for local databases.
Must add the following to .env file in server: 
LOCAL_DATABASE=postgres
LOCAL_USER=postgres
LOCAL_PASSWORD=123456
LOCAL_HOST=localhost
LOCAL_PORT=5432

## Motivation and Context
Some people may not want to use docker or have trouble installing docker on their computer (Windows users).

## How Has This Been Tested?
- in `server/src/database/db.ts` change config passed into pool of database to `localconfig` if using local database (config if on docker), see comments in code

## Screenshots (if appropriate):

# Related Issues
- No issue

# Checklist

