### PR TITLE
added co/prereq_text fields for course reqs

### DIFF
--- a/server/src/database/schema.ts
+++ b/server/src/database/schema.ts
@@ -2,14 +2,16 @@ export const PreReq = `CREATE TABLE PreReq (
     CourseDept VARCHAR(255),
     CourseNumber VARCHAR(255),
     PreReqCourseDept VARCHAR(255),
-    PreReqCourseNumber VARCHAR(255)
+    PreReqCourseNumber VARCHAR(255),
+    PreReqText TEXT
 );`;
 
 export const CoReq = `CREATE TABLE CoReq (
     CourseDept VARCHAR(255),
     CourseNumber VARCHAR(255),
     CoReqCourseDept VARCHAR(255),
-    CoReqCourseNumber VARCHAR(255)
+    CoReqCourseNumber VARCHAR(255),
+    CoReqText TEXT
 );`;
 
 export const CourseSection = `CREATE TABLE CourseSection (

--- a/server/src/database/setup.ts
+++ b/server/src/database/setup.ts
@@ -32,10 +32,10 @@ const populateDb = () => {
         const preReqsToStore: any[] = [];
         const sectionsToStore: any[] = [];
         courses.forEach((course: any) => {
-            const { courseTitle, courseCode, preReqs = [], coReqs = [], sections = [] } = course;
+            const { courseTitle, courseCode, preReqs = [], coReqs = [], sections = [], preReqText, coReqText } = course;
             const [courseDept, courseNumber] = courseCode.split(" ");
-            coReqs.forEach((coReq: any) => handleReq(courseDept, courseNumber, coReq, coReqsToStore));
-            preReqs.forEach((preReq: any) => handleReq(courseDept, courseNumber, preReq, preReqsToStore));
+            coReqs.forEach((coReq: any) => handleReq(courseDept, courseNumber, coReq, coReqText, coReqsToStore));
+            preReqs.forEach((preReq: any) => handleReq(courseDept, courseNumber, preReq, preReqText, preReqsToStore));
             sections.forEach((section: any) => handleSection(courseTitle, courseDept, courseNumber, section, sectionsToStore));
         });
         try {
@@ -57,9 +57,9 @@ const populateDb = () => {
     });
 };
 
-const handleReq = (courseDept: string, courseNumber: string, req: any, store: any[]) => {
+const handleReq = (courseDept: string, courseNumber: string, req: any, plaintext: string, store: any[]) => {
     const [reqCourseDept, reqCourseNumber] = req.split(" ");
-    store.push([courseDept, courseNumber, reqCourseDept, reqCourseNumber]);
+    store.push([courseDept, courseNumber, reqCourseDept, reqCourseNumber, plaintext]);
 };
 
 const handleSection = (courseTitle: string, courseDept: string, courseNumber: string, section: any, store: any[]) => {
@@ -78,7 +78,7 @@ const insertCoReq = (req: []) => insertReq("CoReq", req);
 const insertPreReq = (req: []) => insertReq("PreReq", req);
 
 const insertReq = (table: string, req: []) => {
-    db.query(`INSERT INTO ${table} VALUES ($1, $2, $3, $4)`, req);
+    db.query(`INSERT INTO ${table} VALUES ($1, $2, $3, $4, $5)`, req);
 };
 
 const insertSection = (section: []) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,7 +7,7 @@ import scraper from "../utils/scraper";
 import { setupDb } from "./database/setup";
 import baseRouter from "./routes/index";
 
-const log = parentLogger.child({ module: "express" });
+const log = parentLogger.child({ module: "router" });
 const expressLogger = expressPino(log);
 const PORT = process.env.PORT || 5000;
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,7 +7,7 @@ import scraper from "../utils/scraper";
 import { setupDb } from "./database/setup";
 import baseRouter from "./routes/index";
 
-const log = parentLogger.child({ module: "router" });
+const log = parentLogger.child({ module: "express" });
 const expressLogger = expressPino(log);
 const PORT = process.env.PORT || 5000;
 

--- a/server/utils/scraper.ts
+++ b/server/utils/scraper.ts
@@ -25,7 +25,9 @@ interface Course {
     description: string;
     credits: string;
     preReqs: string[];
+    preReq_text: string;
     coReqs: string[];
+    coReq_text: string;
     sections: Section[];
 }
 
@@ -90,9 +92,9 @@ let getCourseUrls = async (url: string, browser: Browser): Promise<string[]> => 
  *
  * For example, if a course has co-reqs but no pre-reqs: `[[], coreqs]`
  * @param {Page} page Page object for a course listing page
- * @returns {Promise<[string[], string[]]} the tuple containing an array of pre-reqs and an array of co-reqs.
+ * @returns {Promise<any>} an object that holds a list of coreqs, prereqs, and their corresponding plaintext
  */
-let getReqs = async (page: Page): Promise<[string[], string[]]> => {
+let getReqs = async (page: Page): Promise<any> => {
     // preReq <p> may not exist, so .content.expand > p:nth-of-type(3) might be coreq.
     // .content.expand > p:nth-of-type(4) is always a coreq
 
@@ -100,31 +102,52 @@ let getReqs = async (page: Page): Promise<[string[], string[]]> => {
     let preReqs: string[];
     let coReqs: string[];
 
-    let thirdChildHTML = await page.$eval(".content.expand > p:nth-of-type(3)", (p: any) => p.innerHTML)
+    let thirdChildHTML = await page.$eval(".content.expand > p:nth-of-type(3)", (p: any) => p.innerText)
         .catch((err: any) => {
             return [];
         });
-    let fourthChildHTML = await page.$eval(".content.expand > p:nth-of-type(4)", (p: any) => p.innerHTML)
+    let fourthChildHTML = await page.$eval(".content.expand > p:nth-of-type(4)", (p: any) => p.innerText)
         .catch( async (err: any) => {
             return [];
         });
 
     // regex to determine if the html contains pre-req or coreq
-    // this is kind of ugly and i'm sure it can be rewritten to be more readable
+    // sorry this is kind of ugly
     if (/Pre-req/.test(thirdChildHTML)) {
         preReqs = thirdChildHTML.match(courseCodeRegex);
 
         if (/Co-req/.test(fourthChildHTML)) {
             coReqs = fourthChildHTML.match(courseCodeRegex);
-            return [(preReqs || []), (coReqs || [])];
+            return {
+                preReq: preReqs || [],
+                preReq_text: thirdChildHTML,
+                coReq: coReqs || [],
+                coReq_text: fourthChildHTML,
+            };
         }
 
-        return [(preReqs || []), []];
+        return {
+            preReq: preReqs || [],
+            preReq_text: thirdChildHTML,
+            coReq: [],
+            coReq_text: "",
+        };
     } else if (/Co-req/.test(thirdChildHTML)) {
         coReqs = thirdChildHTML.match(courseCodeRegex);
-        return [[], (coReqs || [])];
+
+        return {
+            preReq: [],
+            preReq_text: "",
+            coReq: coReqs || [],
+            coReq_text: thirdChildHTML,
+        };
     } else {
-        return [[], []];
+        return {
+            preReq: [],
+            preReq_text: "",
+            coReq: [],
+            coReq_text: "",
+        };
     }
 };
 
@@ -172,7 +195,7 @@ let getCourseInfo = async (url: string, browser: Browser): Promise<Course> => {
 
     let [ desc, creds ] = await getDescCreds(coursePage);
 
-    let [ preReq, coReq ] = await getReqs(coursePage);
+    let { preReq, preReq_text, coReq, coReq_text} = await getReqs(coursePage);
 
     let courseData: Course = {
         courseTitle: courseTitle,
@@ -180,7 +203,9 @@ let getCourseInfo = async (url: string, browser: Browser): Promise<Course> => {
         description: desc,
         credits: creds,
         preReqs: preReq,
+        preReq_text: preReq_text,
         coReqs: coReq,
+        coReq_text: coReq_text,
         sections: []
     };
 
@@ -354,7 +379,7 @@ let pageConfig = async (page: Page) => {
  *
  * If given an argument, it scrapes the information of a specific course and outputs that to ./utils/output_test.json
  *
- * Some recommended arguments are **145** (tests multi-term courses), **67** (tests prereqs), and **118** (tests courses that have different day/times)
+ * Some recommended arguments are **145** (tests multi-term courses), **67** (tests prereqs), **118** (tests courses that have different day/times), **72** (CPSC)
  *
  * @param {number} [subjectTest] (optional) The row index (between [0, 237] inclusive) of a course on the main [Course Schedule](https://courses.students.ubc.ca/cs/courseschedule?pname=subjarea&tname=subj-all-departments) page
  */

--- a/server/utils/scraper.ts
+++ b/server/utils/scraper.ts
@@ -2,7 +2,6 @@ import { Browser, ElementHandle, JSHandle, LaunchOptions, Page } from "puppeteer
 import puppeteer from "puppeteer";
 import fs from "fs";
 import parentLogger from "./logger";
-import logger from "./logger";
 
 interface TermTime {
     term: string;
@@ -25,9 +24,9 @@ interface Course {
     description: string;
     credits: string;
     preReqs: string[];
-    preReq_text: string;
+    preReqText: string;
     coReqs: string[];
-    coReq_text: string;
+    coReqText: string;
     sections: Section[];
 }
 
@@ -120,33 +119,33 @@ let getReqs = async (page: Page): Promise<any> => {
             coReqs = fourthChildHTML.match(courseCodeRegex);
             return {
                 preReq: preReqs || [],
-                preReq_text: thirdChildHTML,
+                preReqText: thirdChildHTML,
                 coReq: coReqs || [],
-                coReq_text: fourthChildHTML,
+                coReqText: fourthChildHTML,
             };
         }
 
         return {
             preReq: preReqs || [],
-            preReq_text: thirdChildHTML,
+            preReqText: thirdChildHTML,
             coReq: [],
-            coReq_text: "",
+            coReqText: "",
         };
     } else if (/Co-req/.test(thirdChildHTML)) {
         coReqs = thirdChildHTML.match(courseCodeRegex);
 
         return {
             preReq: [],
-            preReq_text: "",
+            preReqText: "",
             coReq: coReqs || [],
-            coReq_text: thirdChildHTML,
+            coReqText: thirdChildHTML,
         };
     } else {
         return {
             preReq: [],
-            preReq_text: "",
+            preReqText: "",
             coReq: [],
-            coReq_text: "",
+            coReqText: "",
         };
     }
 };
@@ -195,7 +194,7 @@ let getCourseInfo = async (url: string, browser: Browser): Promise<Course> => {
 
     let [ desc, creds ] = await getDescCreds(coursePage);
 
-    let { preReq, preReq_text, coReq, coReq_text} = await getReqs(coursePage);
+    let { preReq, preReqText, coReq, coReq_text} = await getReqs(coursePage);
 
     let courseData: Course = {
         courseTitle: courseTitle,
@@ -203,9 +202,9 @@ let getCourseInfo = async (url: string, browser: Browser): Promise<Course> => {
         description: desc,
         credits: creds,
         preReqs: preReq,
-        preReq_text: preReq_text,
+        preReqText: preReqText,
         coReqs: coReq,
-        coReq_text: coReq_text,
+        coReqText: coReq_text,
         sections: []
     };
 


### PR DESCRIPTION
# Changes
- same as title, each course now has a coreq_text and prereq_text field containing the plaintext of each

## Motivation and Context
generating the exact context for course reqs is a bit complicated. for the MVP, all we want is to know the requisites for the course.

## How Has This Been Tested?
- CPSC tests: 
![image](https://user-images.githubusercontent.com/23158004/98460360-97a5db80-2158-11eb-9ad4-1d1ab5a1d70b.png)
![image](https://user-images.githubusercontent.com/23158004/98460370-b60bd700-2158-11eb-9ef5-3482ceb18c87.png)
- sample scraper output
![image](https://user-images.githubusercontent.com/23158004/98460386-db98e080-2158-11eb-8ea1-61117a393e79.png)
![image](https://user-images.githubusercontent.com/23158004/98460392-ebb0c000-2158-11eb-88ef-159d2a185f65.png)

# Related Issues
- temporary fix for issue #33 

fun fact: for some reason, the scraper only took 86 minutes this time from the original 7hrs -> 3hrs :0