### PR TITLE
adding scheduling filter for non-lecture types

### DIFF
--- a/client/src/util/testData.ts
+++ b/client/src/util/testData.ts
@@ -2057,5 +2057,57 @@ export const testData = [
         day: "Fri",
         starttime: "11:00",
         endtime: "12:00"
-        }
+        },
+        {
+        coursetitle: "HIST 100 What is History?",
+        coursedept:	"HIST",
+        coursenumber: "100",
+        sectiontitle: "HIST 100 201",
+        status:	"",
+        activity: "Web-Oriented Course",
+        prof: "FRENCH, WILLIAM EARL",
+        term: "2",
+        day: "Tue Thu",
+        starttime: "14:00",
+        endtime: "15:30"
+    },
+    {
+        coursetitle: "HIST 100 What is History?",
+        coursedept:	"HIST",
+        coursenumber: "100",
+        sectiontitle: "HIST 100 L1B",
+        status:	"",
+        activity: "Discussion",
+        prof: "",
+        term: "2",
+        day: "Fri",
+        starttime: "11:00",
+        endtime: "12:00",
+    },
+    {
+        coursetitle: "HIST 100 What is History?",
+        coursedept:	"HIST",
+        coursenumber: "100",
+        sectiontitle: "HIST 100 L1A",
+        status:	"",
+        activity: "Discussion",
+        prof: "",
+        term: "2",
+        day: "Thu",
+        starttime: "15:30",
+        endtime: "16:30"
+    },
+    {
+        coursetitle: "CHEM 448A Directed Studies in Chemistry - T1 DST CHEMISTRY",
+        coursedept:	"CHEM",
+        coursenumber: "448A",
+        sectiontitle: "CHEM 448A 100",
+        status: "Blocked",
+        activity: "Directed Studies",
+        prof: "",
+        term: "1",
+        day: "",
+        starttime: "",
+        endtime: ""
+    }
 ];

--- a/client/src/util/testScheduler.ts
+++ b/client/src/util/testScheduler.ts
@@ -24,24 +24,24 @@ export interface CourseSection {
  * NOTE: My types here are generic because there might be more changes to schema, so don't want to lock in types just yet
  */
 export const filterLectures = (courseSections: CourseSection[]): CourseSection[] => {
-    const lectures = courseSections.filter(isLectureType);
+    const lectures = courseSections.filter(filterActivityTypes);
     return lectures;
 };
 
 /**
  * helper function for filterLectures
  * @param {CourseSection} courseSection a course section
- * @returns {boolean} returns false if a section's type is any of lectureTypes
+ * @returns {boolean} returns false if a section's type is any of unwantedTypes
  */
-export const isLectureType = (courseSection: CourseSection) => {
+export const filterActivityTypes = (courseSection: CourseSection) => {
     const activity = courseSection["activity"];
-    const lectureTypes = [
+    const unwantedTypes = [
         "Waiting List",
         "Tutorial",
         "Laboratory",
         "Discussion"
     ];
-    return !lectureTypes.some((lectureType: string) => activity === lectureType);
+    return !unwantedTypes.some((unwantedType: string) => activity === unwantedType);
 };
 
 

--- a/client/src/util/testScheduler.ts
+++ b/client/src/util/testScheduler.ts
@@ -19,14 +19,29 @@ export interface CourseSection {
 
 /**
  * Given an array of course sections, filter out non Web-Oriented sections (no labs, waiting lists etc)
- * TODO: For testing purposes, I'm only filtering for Web Oriented Course, but there will be other types of valid lectures
  * @param {CourseSection[]} courseSections array of course sections (of all types including lectures, labs, waitlists)
  * @returns {CourseSection[]} An array of course sections which only contains "lecture" type
  * NOTE: My types here are generic because there might be more changes to schema, so don't want to lock in types just yet
  */
 export const filterLectures = (courseSections: CourseSection[]): CourseSection[] => {
-    const lectures = courseSections.filter((coursesection: CourseSection) => coursesection["activity"] === "Web-Oriented Course");
+    const lectures = courseSections.filter(isLectureType);
     return lectures;
+};
+
+/**
+ * helper function for filterLectures
+ * @param {CourseSection} courseSection a course section
+ * @returns {boolean} returns false if a section's type is any of lectureTypes
+ */
+export const isLectureType = (courseSection: CourseSection) => {
+    const activity = courseSection["activity"];
+    const lectureTypes = [
+        "Waiting List",
+        "Tutorial",
+        "Laboratory",
+        "Discussion"
+    ];
+    return !lectureTypes.some((lectureType: string) => activity === lectureType);
 };
 
 


### PR DESCRIPTION
# Changes
- changed the lecture type filter from only including "web-oriented course" to allowing all but waitlist, lab, discussion and tutorial

## Motivation and Context
- completes one of the scheduler's TODOs

## How Has This Been Tested?
i added a HIST course (has Discussions) and a Directed Studies course to show that other types of lectures are being considered now, while still filtering the sections we don't want. the # of combinations remains the same as the last scheduling PR, which is desired behaviour

## Screenshots
![image](https://user-images.githubusercontent.com/23158004/99589610-17c21180-29a1-11eb-82f9-d888fb26b462.png)

![image](https://user-images.githubusercontent.com/23158004/99589162-80f55500-29a0-11eb-84de-04619f78b5b3.png)

# Related Issues
- #77

