### PR TITLE
Stop Creation/Repopulation of DB if tables already exist

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -8,3 +8,6 @@
 
 # DB config
 .env
+
+# Compiled JS files
+*.js

--- a/server/src/database/setup.ts
+++ b/server/src/database/setup.ts
@@ -7,8 +7,9 @@ const log = parentLogger.child({ module: "router" });
 const src = "./utils/output.json";
 
 export const setupDb = async () => {
-    const { rows: tables } = await getTables();
-    if (tables.every((table) => ["prereq", "coreq", "coursesection"].includes(table.table_name))) {
+    let { rows: tables } = await getTables();
+    tables = tables.map((table) => table.table_name);
+    if (["prereq", "coreq", "coursesection"].every((name) => tables.includes(name))) {
         log.info("Tables already exist. Will not be re-creating the DB.");
         return;
     }

--- a/server/src/database/setup.ts
+++ b/server/src/database/setup.ts
@@ -7,6 +7,11 @@ const log = parentLogger.child({ module: "router" });
 const src = "./utils/output.json";
 
 export const setupDb = async () => {
+    const { rows: tables } = await getTables();
+    if (tables.every((table) => ["prereq", "coreq", "coursesection"].includes(table.table_name))) {
+        log.info("Tables already exist. Will not be re-creating the DB.");
+        return;
+    }
     await dropDb();
     await createDb();
     await populateDb();
@@ -84,3 +89,10 @@ const insertReq = (table: string, req: []) => {
 const insertSection = (section: []) => {
     db.query("INSERT INTO CourseSection VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)", section);
 };
+
+const getTables = () => db.query(`
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE table_schema='public'
+    AND table_type='BASE TABLE';
+`);


### PR DESCRIPTION
# Changes
* prevents re-creation and re-population of DB if the tables already exist

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* makes server restarts faster

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* ran server locally and observed that the DB does not drop/create/populate tables if the tables already exist

## Screenshots (if appropriate):

# Related Issues
- Closes issue #82 

# Checklist

