### PR TITLE
Added server start script to automate usage of localconfig vs non-local config for DB

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,7 @@
     "scripts": {
         "start": "ts-node-dev --respawn src/index.ts",
         "start:local": "DB_LOCAL=true ts-node-dev --respawn src/index.ts",
+        "start:localwindows": "set DB_LOCAL=true && ts-node-dev --respawn src/index.ts",
         "dev": "nodemon -L --exec ts-node src/index.ts",
         "build": "tsc",
         "lint": "eslint . --ext .ts",

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
     "main": "index.js",
     "scripts": {
         "start": "ts-node-dev --respawn src/index.ts",
-        "start:local": "DB_ENV=local ts-node-dev --respawn src/index.ts",
+        "start:local": "DB_LOCAL=true ts-node-dev --respawn src/index.ts",
         "dev": "nodemon -L --exec ts-node src/index.ts",
         "build": "tsc",
         "lint": "eslint . --ext .ts",

--- a/server/package.json
+++ b/server/package.json
@@ -4,6 +4,7 @@
     "main": "index.js",
     "scripts": {
         "start": "ts-node-dev --respawn src/index.ts",
+        "start:local": "DB_ENV=local ts-node-dev --respawn src/index.ts",
         "dev": "nodemon -L --exec ts-node src/index.ts",
         "build": "tsc",
         "lint": "eslint . --ext .ts",

--- a/server/src/database/db.ts
+++ b/server/src/database/db.ts
@@ -10,7 +10,7 @@ class Database {
 
     constructor() {
         // If on docker pool should take config, if on local database pool should take localconfig
-        this.pool = new Pool(config);
+        this.pool = new Pool((process.env.DB_ENV === "local") ? localconfig : config);
         this.pool.on("error", (err, client) => {
             log.error("Unexpected error on idle PostgreSQL client.", err);
             process.exit(-1);

--- a/server/src/database/db.ts
+++ b/server/src/database/db.ts
@@ -10,7 +10,7 @@ class Database {
 
     constructor() {
         // If on docker pool should take config, if on local database pool should take localconfig
-        this.pool = new Pool((process.env.DB_ENV === "local") ? localconfig : config);
+        this.pool = new Pool((process.env.DB_LOCAL) ? localconfig : config);
         this.pool.on("error", (err, client) => {
             log.error("Unexpected error on idle PostgreSQL client.", err);
             process.exit(-1);


### PR DESCRIPTION
# Changes
* Added server start script to automate usage of localconfig vs non-local config for DB

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* you can run `yarn start:local` to use the local config for the DB instead of having to manually change the config variable in the code

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

# Related Issues
- Closes issue #88 

# Checklist

