### PR TITLE
Delete course

### DIFF
--- a/client/src/actions/HomeActions.ts
+++ b/client/src/actions/HomeActions.ts
@@ -7,6 +7,7 @@ export const ADDCOURSE = "add_course";
 export const ADDCOURSESECTIONS = "add_course_sections";
 export const SETVALIDSCHEDULES = "set_valid_schedules";
 export const SETSELECTEDSCHEDULE = "set_selected_schedule";
+export const DELETCOURSE = "delete_course";
 
 export interface SelectTerm {
   type: typeof SELECTTERM;
@@ -37,4 +38,16 @@ export interface SetSelectedSchedule {
   selectedSchedule: number;
 }
 
-export type HomeActions = Switch | AddCourse | AddCourseSections | SelectTerm | SetValidSchedules | SetSelectedSchedule;
+export interface DeleteCourse {
+  type: typeof DELETCOURSE;
+  courses: string[];
+}
+
+export type HomeActions =
+  | Switch
+  | AddCourse
+  | AddCourseSections
+  | SelectTerm
+  | SetValidSchedules
+  | SetSelectedSchedule
+  | DeleteCourse;

--- a/client/src/components/CourseItem.tsx
+++ b/client/src/components/CourseItem.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ClearIcon from "@material-ui/icons/Clear";
 import styled from "styled-components";
 
 const StyledItem = styled.div`
@@ -12,7 +13,15 @@ interface CourseItemProps {
   courseName: string;
 }
 function CourseItem({ courseName }: CourseItemProps) {
-  return <StyledItem>{courseName}</StyledItem>;
+  return (
+    <StyledItem>
+      {courseName}
+      <ClearIcon
+        style={{ lineHeight: 40, cursor: "pointer" }}
+        fontSize='small'
+      ></ClearIcon>
+    </StyledItem>
+  );
 }
 
 export default CourseItem;

--- a/client/src/components/CourseItem.tsx
+++ b/client/src/components/CourseItem.tsx
@@ -18,7 +18,7 @@ function CourseItem({ courseName }: CourseItemProps) {
       {courseName}
       <ClearIcon
         style={{ lineHeight: 40, cursor: "pointer" }}
-        fontSize='small'
+        fontSize="small"
       ></ClearIcon>
     </StyledItem>
   );

--- a/client/src/components/Courses.tsx
+++ b/client/src/components/Courses.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import Title from "./Title";
-import CourseItem from "./CourseItem";
 import Snackbar from "@material-ui/core/Snackbar";
 import {
   AddCourse,
@@ -39,7 +38,7 @@ const AddCourseSection = styled.div`
 
 const CourseList = styled.div`
   display: inline-block;
-  height: 250px;
+  height: 262px;
   border: 1px solid #c4c4c4;
   border-radius: 10px;
   flex: 3;
@@ -129,30 +128,29 @@ function Courses({
   const handleDltBtnClick = (deletedCourse: string) => {
     const coursesAfterDeletion = coursesAdded
       ? coursesAdded.filter((course) => course !== deletedCourse)
-      : null;
-    console.log(coursesAfterDeletion);
-    deleteCourseInRedux([coursesAfterDeletion]);
+      : [];
+    deleteCourseInRedux(coursesAfterDeletion);
   };
 
   return (
     <Section>
-      <Title title='2. Add Courses'></Title>
+      <Title title="2. Add Courses"></Title>
       <Wrapper>
         <AddCourseSection>
           <span style={{ fontSize: 30 }}>Course:</span>
           <TextField
-            id='outlined-textarea'
-            variant='outlined'
+            id="outlined-textarea"
+            variant="outlined"
             onChange={handleChange}
             style={{ width: 250, height: 50, marginLeft: 10 }}
           />
           <Button
-            variant='contained'
-            color='secondary'
+            variant="contained"
+            color="secondary"
             style={{
               display: "block",
               marginTop: 164,
-              marginLeft: 400,
+              marginLeft: 360,
               color: "white",
             }}
             onClick={handleAddBtnClick}
@@ -160,7 +158,6 @@ function Courses({
             Add
           </Button>
         </AddCourseSection>
-
         <CourseList>
           {coursesAdded && coursesAdded.length > 0
             ? coursesAdded.map((course, index) => {
@@ -174,8 +171,8 @@ function Courses({
                       <ListItemText primary={course} />
                       <ListItemSecondaryAction>
                         <IconButton
-                          edge='end'
-                          aria-label='delete'
+                          edge="end"
+                          aria-label="delete"
                           onClick={() => {
                             handleDltBtnClick(course);
                           }}
@@ -195,7 +192,7 @@ function Courses({
         open={open}
         onClose={handleSnackBarClose}
         message={message}
-        key='topcenter'
+        key="topcenter"
       />
     </Section>
   );

--- a/client/src/components/Courses.tsx
+++ b/client/src/components/Courses.tsx
@@ -11,8 +11,15 @@ import {
 import styled from "styled-components";
 import Section from "./Section";
 import Button from "@material-ui/core/Button";
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemSecondaryAction from "@material-ui/core/ListItemSecondaryAction";
+import ListItemText from "@material-ui/core/ListItemText";
+import DeleteIcon from "@material-ui/icons/Delete";
+import IconButton from "@material-ui/core/IconButton";
 import TextField from "@material-ui/core/TextField";
 import axios from "axios";
+import { DELETCOURSE, DeleteCourse } from "../actions/HomeActions";
 import { RootState } from "../reducers/index";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
@@ -36,6 +43,7 @@ const CourseList = styled.div`
   border: 1px solid #c4c4c4;
   border-radius: 10px;
   flex: 3;
+  overflow: scroll;
 `;
 
 export interface CourseObjectProps {
@@ -56,6 +64,7 @@ interface CoursesProps {
   coursesAdded?: string[];
   addCourseToRedux?: any;
   addSectionsToRedux?: any;
+  deleteCourseInRedux?: any;
   sections?: CourseObjectProps[];
   term?: string;
 }
@@ -65,6 +74,7 @@ function Courses({
   addCourseToRedux,
   sections,
   addSectionsToRedux,
+  deleteCourseInRedux,
   term,
 }: CoursesProps) {
   // snackbar:
@@ -116,21 +126,29 @@ function Courses({
     setOpen(true);
   };
 
+  const handleDltBtnClick = (deletedCourse: string) => {
+    const coursesAfterDeletion = coursesAdded
+      ? coursesAdded.filter((course) => course !== deletedCourse)
+      : null;
+    console.log(coursesAfterDeletion);
+    deleteCourseInRedux([coursesAfterDeletion]);
+  };
+
   return (
     <Section>
-      <Title title="2. Add Courses"></Title>
+      <Title title='2. Add Courses'></Title>
       <Wrapper>
         <AddCourseSection>
           <span style={{ fontSize: 30 }}>Course:</span>
           <TextField
-            id="outlined-textarea"
-            variant="outlined"
+            id='outlined-textarea'
+            variant='outlined'
             onChange={handleChange}
             style={{ width: 250, height: 50, marginLeft: 10 }}
           />
           <Button
-            variant="contained"
-            color="secondary"
+            variant='contained'
+            color='secondary'
             style={{
               display: "block",
               marginTop: 164,
@@ -142,11 +160,31 @@ function Courses({
             Add
           </Button>
         </AddCourseSection>
+
         <CourseList>
-          {coursesAdded
+          {coursesAdded && coursesAdded.length > 0
             ? coursesAdded.map((course, index) => {
                 return (
-                  <CourseItem key={index} courseName={course}></CourseItem>
+                  <List
+                    style={{ borderBottom: "1px solid #eee" }}
+                    key={index}
+                    dense={false}
+                  >
+                    <ListItem>
+                      <ListItemText primary={course} />
+                      <ListItemSecondaryAction>
+                        <IconButton
+                          edge='end'
+                          aria-label='delete'
+                          onClick={() => {
+                            handleDltBtnClick(course);
+                          }}
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      </ListItemSecondaryAction>
+                    </ListItem>
+                  </List>
                 );
               })
             : null}
@@ -157,7 +195,7 @@ function Courses({
         open={open}
         onClose={handleSnackBarClose}
         message={message}
-        key="topcenter"
+        key='topcenter'
       />
     </Section>
   );
@@ -184,6 +222,13 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
       const action: AddCourseSections = {
         type: ADDCOURSESECTIONS,
         sections,
+      };
+      dispatch(action);
+    },
+    deleteCourseInRedux(courses: string[]) {
+      const action: DeleteCourse = {
+        type: DELETCOURSE,
+        courses,
       };
       dispatch(action);
     },

--- a/client/src/reducers/HomeReducer.ts
+++ b/client/src/reducers/HomeReducer.ts
@@ -21,7 +21,7 @@ export interface HomeReducerProps {
 }
 
 const initialState: HomeReducerProps = {
-  componentIndex: 1,
+  componentIndex: 0,
   coursesAdded: [],
   sections: [],
   term: "1",

--- a/client/src/reducers/HomeReducer.ts
+++ b/client/src/reducers/HomeReducer.ts
@@ -6,7 +6,8 @@ import {
   ADDCOURSESECTIONS,
   SELECTTERM,
   SETVALIDSCHEDULES,
-  SETSELECTEDSCHEDULE
+  SETSELECTEDSCHEDULE,
+  DELETCOURSE,
 } from "../actions/HomeActions";
 import { CourseSection } from "../util/testScheduler";
 
@@ -20,12 +21,12 @@ export interface HomeReducerProps {
 }
 
 const initialState: HomeReducerProps = {
-  componentIndex: 0,
+  componentIndex: 1,
   coursesAdded: [],
   sections: [],
   term: "1",
   schedules: [],
-  selectedSchedule: 0 // TODO: Should this be defaulted to 1?
+  selectedSchedule: 0, // TODO: Should this be defaulted to 1?
 };
 
 export const HomeReducer = (
@@ -50,6 +51,9 @@ export const HomeReducer = (
     }
     case SETSELECTEDSCHEDULE: {
       return { ...state, selectedSchedule: action.selectedSchedule };
+    }
+    case DELETCOURSE: {
+      return { ...state, coursesAdded: action.courses };
     }
     default:
       return state;


### PR DESCRIPTION
# Changes
- Courses that have been added now can be deleted
- Modified add btn pos so that it aligns with the input text field
- Course list can now render more than 4 courses with scrolling

## Motivation and Context
- We need to allow users to delete some of added courses

## How Has This Been Tested?
- A single course item can be deleted by the delete icon 
- Changes can also be manifested in redux dev tool

## Screenshots (if appropriate):
![Screen Shot 2020-12-04 at 12 10 21 PM](https://user-images.githubusercontent.com/40585236/101210425-50f9b300-362a-11eb-96d8-f5c161cee647.png)
![Screen Shot 2020-12-04 at 12 10 18 PM](https://user-images.githubusercontent.com/40585236/101210429-51924980-362a-11eb-9ff9-2904903a8373.png)

## Related issues:
- For now, sections will remain intact after deletion in courses. I am not sure whether it is necessary to remove sections after corresponding courses have been deleted. 