### PR TITLE
feat/lock sections

### DIFF
--- a/client/src/actions/HomeActions.ts
+++ b/client/src/actions/HomeActions.ts
@@ -3,12 +3,12 @@ import { CourseSection } from "../util/testScheduler";
 
 export const SELECTTERM = "select_term";
 export const SWITCHCOMPONENT = "switch_component";
-export const ADDCOURSE = "add_course";
 export const ADDCOURSESECTIONS = "add_course_sections";
 export const SELECTDAYS = "select_days";
+export const SETCOURSES = "set_courses";
 export const SETVALIDSCHEDULES = "set_valid_schedules";
 export const SETSELECTEDSCHEDULE = "set_selected_schedule";
-export const DELETCOURSE = "delete_course";
+export const SETSELECTEDSECTIONS = "set_selected_sections";
 
 export interface SelectTerm {
   type: typeof SELECTTERM;
@@ -20,11 +20,6 @@ export interface Switch {
   index: number;
 }
 
-export interface AddCourse {
-  type: typeof ADDCOURSE;
-  courses: string[];
-}
-
 export interface AddCourseSections {
   type: typeof ADDCOURSESECTIONS;
   sections: CourseObjectProps[];
@@ -34,10 +29,17 @@ export interface SelectDays {
   type: typeof SELECTDAYS;
   days: number[];
 }
+
+export interface SetCourses {
+  type: typeof SETCOURSES;
+  courses: string[];
+}
+
 export interface SetValidSchedules {
   type: typeof SETVALIDSCHEDULES;
   schedules: CourseSection[][];
 }
+
 export interface SetSelectedSchedule {
   type: typeof SETSELECTEDSCHEDULE;
   selectedSchedule: CourseSection[];
@@ -50,10 +52,10 @@ export interface DeleteCourse {
 
 export type HomeActions =
   | Switch
-  | AddCourse
   | AddCourseSections
   | SelectTerm
   | SelectDays
+  | SetCourses
   | SetValidSchedules
   | SetSelectedSchedule
   | DeleteCourse;

--- a/client/src/actions/HomeActions.ts
+++ b/client/src/actions/HomeActions.ts
@@ -45,9 +45,9 @@ export interface SetSelectedSchedule {
   selectedSchedule: CourseSection[];
 }
 
-export interface DeleteCourse {
-  type: typeof DELETCOURSE;
-  courses: string[];
+export interface SetSelectedSections {
+  type: typeof SETSELECTEDSECTIONS;
+  selectedSections: string[];
 }
 
 export type HomeActions =
@@ -58,4 +58,4 @@ export type HomeActions =
   | SetCourses
   | SetValidSchedules
   | SetSelectedSchedule
-  | DeleteCourse;
+  | SetSelectedSections;

--- a/client/src/components/Courses.tsx
+++ b/client/src/components/Courses.tsx
@@ -2,10 +2,8 @@ import React, { useState } from "react";
 import Title from "./Title";
 import Snackbar from "@material-ui/core/Snackbar";
 import {
-  AddCourse,
-  ADDCOURSE,
-  AddCourseSections,
-  ADDCOURSESECTIONS,
+  SetCourses, SETCOURSES,
+  AddCourseSections, ADDCOURSESECTIONS,
 } from "../actions/HomeActions";
 import styled from "styled-components";
 import Section from "./Section";
@@ -19,7 +17,6 @@ import IconButton from "@material-ui/core/IconButton";
 import TextField from "@material-ui/core/TextField";
 import { MESSAGE } from "../util/constants";
 import axios from "axios";
-import { DELETCOURSE, DeleteCourse } from "../actions/HomeActions";
 import { RootState } from "../reducers/index";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
@@ -66,21 +63,19 @@ export interface CourseObjectProps {
 }
 
 interface CoursesProps {
-  coursesAdded?: string[];
-  addCourseToRedux: (coursesAdded: string[]) => void;
-  addSectionsToRedux: (sections: CourseObjectProps[]) => void;
-  deleteCourseInRedux: (courses: string[]) => void;
-  sections?: CourseObjectProps[];
   term?: string;
+  sections?: CourseObjectProps[];
+  coursesAdded?: string[];
+  addSectionsToRedux: (sections: CourseObjectProps[]) => void;
+  setCoursesToRedux: (courses: string[]) => void;
 }
 
 function Courses({
-  coursesAdded,
-  addCourseToRedux,
-  sections,
-  addSectionsToRedux,
-  deleteCourseInRedux,
   term,
+  sections,
+  coursesAdded,
+  addSectionsToRedux,
+  setCoursesToRedux,
 }: CoursesProps) {
   // snackbar:
   const [open, setOpen] = useState(false);
@@ -119,7 +114,7 @@ function Courses({
     if (response.data.length === 0) {
       setMessage(MESSAGE.COURSE_NOT_EXIST);
     } else if (coursesAdded && !coursesAdded.includes(correctedCourse)) {
-      addCourseToRedux([...(coursesAdded as string[]), correctedCourse]);
+      setCoursesToRedux([...(coursesAdded as string[]), correctedCourse]);
       const courseSections: CourseObjectProps[] = response.data;
       addSectionsToRedux(
         sections ? sections.concat(courseSections) : courseSections
@@ -144,7 +139,7 @@ function Courses({
         )
       : [];
     addSectionsToRedux(sectionsAfterDeletion);
-    deleteCourseInRedux(coursesAfterDeletion);
+    setCoursesToRedux(coursesAfterDeletion);
   };
 
   return (
@@ -223,9 +218,9 @@ const mapStateToProps = (state: RootState) => {
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
-    addCourseToRedux(coursesAdded: string[]) {
-      const action: AddCourse = {
-        type: ADDCOURSE,
+    setCoursesToRedux(coursesAdded: string[]) {
+      const action: SetCourses = {
+        type: SETCOURSES,
         courses: coursesAdded,
       };
       dispatch(action);
@@ -234,13 +229,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
       const action: AddCourseSections = {
         type: ADDCOURSESECTIONS,
         sections,
-      };
-      dispatch(action);
-    },
-    deleteCourseInRedux(courses: string[]) {
-      const action: DeleteCourse = {
-        type: DELETCOURSE,
-        courses,
       };
       dispatch(action);
     },

--- a/client/src/components/Labs.tsx
+++ b/client/src/components/Labs.tsx
@@ -29,7 +29,7 @@ function Labs({selectedSchedule, notLectureSections, setSelectedSchedule}: LabsP
     <Section>
       <Title title="5. Add Lab Sections"></Title>
       <div style={{ display: "flex" }}>
-        <ScheduleGrid></ScheduleGrid>
+        <ScheduleGrid />
         <div>
           {Object.keys(notLectureSections).map((notLectureSectionTitle: string, i) => {
             const currNotLectureSections = notLectureSections[notLectureSectionTitle];

--- a/client/src/components/Lectures.tsx
+++ b/client/src/components/Lectures.tsx
@@ -13,11 +13,13 @@ import {
 } from "../actions/HomeActions";
 interface LectureProps {
   schedules: CourseSection[][];
+  selectedSections: string[];
   setSelectedSchedule?: any;
 }
 
 function Lectures({
   schedules,
+  selectedSections,
   setSelectedSchedule,
 }: LectureProps) {
   const [selected, setSelected] = useState(0);
@@ -27,25 +29,31 @@ function Lectures({
   };
 
   useEffect(() => {
-    setSelectedSchedule(schedules[0]);
+    setSelectedSchedule(schedules[0] || []);
   }, []);
+
+  useEffect(() => {
+    setSelected(0);
+  }, [selectedSections]);
 
   return (
     <Section>
       <Title title="4. Select Lectures to Lock Them"></Title>
       {schedules[selected] && <ScheduleGrid schedule={schedules[selected]} />}
       <Pagination
-        count={schedules.length}
         shape="rounded"
+        page={selected + 1}
+        count={schedules.length}
         onChange={handleChange}
       />
     </Section>
   );
 }
 
-const mapStateToProps = (state: RootState) => {
+const mapStateToProps = ({ HomeReducer: { sections, days, selectedSections } }: RootState) => {
   return {
-    schedules: generateSchedules(state.HomeReducer.sections, state.HomeReducer.days),
+    schedules: generateSchedules(sections, days, selectedSections),
+    selectedSections,
   };
 };
 

--- a/client/src/components/ScheduleGrid.tsx
+++ b/client/src/components/ScheduleGrid.tsx
@@ -7,11 +7,13 @@ import TableContainer from "@material-ui/core/TableContainer";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import Paper from "@material-ui/core/Paper";
+import { Dispatch } from "redux";
 import { makeStyles } from "@material-ui/core/styles";
 import { CourseSection } from "../util/testScheduler";
 
 import { RootState } from "../reducers/index";
 import { connect } from "react-redux";
+import { SETSELECTEDSECTIONS, SetSelectedSections } from "../actions/HomeActions";
 
 const colors = ["#1BAFD0", "#FD636B", "#FFB900", "#3BE8B0", "#6967C1"];
 
@@ -27,8 +29,8 @@ function makerows(start: number, end: number) {
     return rows;
 }
 
-function addCourse(rows: any, day: any, startTime: number, endTime: number, courseName: string, i: number) {
-    if (startTime >= endTime || courseName === "" || courseName === null) return;
+function addCourse(rows: any, day: any, startTime: number, endTime: number, sectionTitle: string, i: number) {
+    if (startTime >= endTime || sectionTitle === "" || sectionTitle === null) return;
     for (let timeslot of rows) {
         let currTime = timeslot.id;
         let currHour: number = +currTime.slice(0, -3);
@@ -37,7 +39,7 @@ function addCourse(rows: any, day: any, startTime: number, endTime: number, cour
         if (currHour >= startTime && currHour < endTime) {
             timeslot[day] = {
                 align: "center",
-                courseName,
+                sectionTitle,
                 rowSpan: (endTime - startTime) * 2,
                 style: {
                     background: colors[i % 5],
@@ -57,13 +59,22 @@ const useStyles = makeStyles({
 interface ScheduleGridProps {
     schedule?: CourseSection[];
     selectedSchedule: CourseSection[];
+    selectedSections: string[];
+    setSelectedSections: (selectedSections: string[]) => void;
 }
 
 /* Main Function that Generates the Grid */
-function ScheduleGrid({ schedule, selectedSchedule }: ScheduleGridProps) {
+function ScheduleGrid({ schedule, selectedSchedule, selectedSections, setSelectedSections }: ScheduleGridProps) {
     const classes = useStyles();
     const startHour = 8, endHour = 20;
     const rows = makerows(startHour, endHour);
+
+    const toggleSection = (sectionTitle: string) => () => {
+        const sections = selectedSections.includes(sectionTitle)
+        ? selectedSections.filter((section: string) => section !== sectionTitle)
+        : [...selectedSections, sectionTitle];
+        setSelectedSections([...sections]);
+    };
 
     (schedule ? schedule : selectedSchedule).forEach((section: any, i: number) => {
         const { sectiontitle, starttime = "", endtime = "", day = "" } = section;
@@ -75,9 +86,12 @@ function ScheduleGrid({ schedule, selectedSchedule }: ScheduleGridProps) {
         days.forEach((dayOfWeek: any) => addCourse(rows, dayOfWeek, start, end, sectiontitle, i));
     });
 
-    function ScheduleCell({ courseName = "", ...props }: any) {
+    function ScheduleCell({ sectionTitle = "", ...props }: any) {
         return (
-            <TableCell {...props}>{courseName}</TableCell>
+            <TableCell {...props} onClick={toggleSection(sectionTitle)}>
+                {sectionTitle}
+                {selectedSections.includes(sectionTitle) && " (selected)"}
+            </TableCell>
         );
     }
 
@@ -134,7 +148,20 @@ function ScheduleGrid({ schedule, selectedSchedule }: ScheduleGridProps) {
 const mapStateToProps = (state: RootState) => {
     return {
       selectedSchedule: state.HomeReducer.selectedSchedule,
+      selectedSections: state.HomeReducer.selectedSections,
     };
 };
 
-export default connect(mapStateToProps)(ScheduleGrid);
+const mapDispatchToProps = (dispatch: Dispatch) => {
+    return {
+      setSelectedSections(selectedSections: string[]) {
+        const action: SetSelectedSections = {
+          type: SETSELECTEDSECTIONS,
+          selectedSections,
+        };
+        dispatch(action);
+      },
+    };
+  };
+
+export default connect(mapStateToProps, mapDispatchToProps)(ScheduleGrid);

--- a/client/src/reducers/HomeReducer.ts
+++ b/client/src/reducers/HomeReducer.ts
@@ -2,13 +2,12 @@ import { CourseObjectProps } from "../components/Courses";
 import {
   HomeActions,
   SWITCHCOMPONENT,
-  ADDCOURSE,
   ADDCOURSESECTIONS,
   SELECTTERM,
   SELECTDAYS,
+  SETCOURSES,
   SETVALIDSCHEDULES,
   SETSELECTEDSCHEDULE,
-  DELETCOURSE,
 } from "../actions/HomeActions";
 import { CourseSection } from "../util/testScheduler";
 
@@ -40,9 +39,6 @@ export const HomeReducer = (
     case SWITCHCOMPONENT: {
       return { ...state, componentIndex: action.index };
     }
-    case ADDCOURSE: {
-      return { ...state, coursesAdded: action.courses };
-    }
     case ADDCOURSESECTIONS: {
       return { ...state, sections: action.sections };
     }
@@ -52,14 +48,15 @@ export const HomeReducer = (
     case SELECTDAYS: {
       return { ...state, days: action.days };
     }
+    case SETCOURSES: {
+      return { ...state, coursesAdded: action.courses };
+    }
     case SETVALIDSCHEDULES: {
       return { ...state, schedules: action.schedules };
     }
     case SETSELECTEDSCHEDULE: {
       return { ...state, selectedSchedule: action.selectedSchedule };
     }
-    case DELETCOURSE: {
-      return { ...state, coursesAdded: action.courses };
     }
     default:
       return state;

--- a/client/src/reducers/HomeReducer.ts
+++ b/client/src/reducers/HomeReducer.ts
@@ -8,6 +8,7 @@ import {
   SETCOURSES,
   SETVALIDSCHEDULES,
   SETSELECTEDSCHEDULE,
+  SETSELECTEDSECTIONS,
 } from "../actions/HomeActions";
 import { CourseSection } from "../util/testScheduler";
 
@@ -19,6 +20,7 @@ export interface HomeReducerProps {
   days: number[];
   schedules: CourseSection[][];
   selectedSchedule: CourseSection[];
+  selectedSections: string[];
 }
 
 const initialState: HomeReducerProps = {
@@ -29,6 +31,7 @@ const initialState: HomeReducerProps = {
   term: "1",
   schedules: [],
   selectedSchedule: [],
+  selectedSections: [],
 };
 
 export const HomeReducer = (
@@ -57,6 +60,8 @@ export const HomeReducer = (
     case SETSELECTEDSCHEDULE: {
       return { ...state, selectedSchedule: action.selectedSchedule };
     }
+    case SETSELECTEDSECTIONS: {
+      return { ...state, selectedSections: action.selectedSections };
     }
     default:
       return state;

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -8,13 +8,3 @@ export interface RootState {
 export default combineReducers({
   HomeReducer,
 });
-
-// export const configureStore = (): Store<RootState> => {
-//   const middlewares: Middleware[] = [];
-//   const middleWareEnhancer = applyMiddleware(...middlewares);
-//   const store = createStore(
-//     rootReducer,
-//     composeWithDevTools(middleWareEnhancer)
-//   );
-//   return store;
-// };

--- a/client/src/util/testScheduler.ts
+++ b/client/src/util/testScheduler.ts
@@ -17,10 +17,26 @@ export interface CourseSection {
     endtime: string;
 }
 
-export const generateSchedules = (courses: CourseSection[], restrictedDays: number[] = []): CourseSection[][] => {
+export const generateSchedules = (
+    courses: CourseSection[],
+    restrictedDays: number[] = [],
+    selectedSections: string[] = []): CourseSection[][] => {
     const lectures = filterLectures(courses);
     const schedules = generateCourseScheduleOnlyLectures(lectures, restrictedDays);
-    return schedules;
+    return filterSchedules(schedules, selectedSections);
+};
+
+/**
+ * Given an array of schedules, filter out schedules that contain selected sections
+ * @param {CourseSection[][]} schedules array of schedules based on course selection and restrictions
+ * @param {string[]} selected array of selected sections which must be included in the schedule
+ * @returns {CourseSection[][]} An array of schedules that contain selected sections
+ */
+export const filterSchedules = (schedules: CourseSection[][], selected: string[]): CourseSection[][] => {
+    return schedules.filter((schedule: CourseSection[]) => {
+        const set = new Set(schedule.map(({ sectiontitle }) => sectiontitle));
+        return selected.every((section) => set.has(section));
+    });
 };
 
 /**
@@ -33,7 +49,6 @@ export const filterLectures = (courseSections: CourseSection[]): CourseSection[]
     const lectures = courseSections.filter(filterActivityTypes);
     return lectures;
 };
-
 
 /**
  * Given an array of course sections, filter out non Web-Oriented sections (no labs, waiting lists etc)

--- a/client/src/util/testScheduler.ts
+++ b/client/src/util/testScheduler.ts
@@ -27,10 +27,10 @@ export const generateSchedules = (
 };
 
 /**
- * Given an array of schedules, filter out schedules that contain selected sections
+ * Given an array of schedules, filter out schedules that does not contain all selected sections
  * @param {CourseSection[][]} schedules array of schedules based on course selection and restrictions
  * @param {string[]} selected array of selected sections which must be included in the schedule
- * @returns {CourseSection[][]} An array of schedules that contain selected sections
+ * @returns {CourseSection[][]} An array of schedules that contain all selected sections
  */
 export const filterSchedules = (schedules: CourseSection[][], selected: string[]): CourseSection[][] => {
     return schedules.filter((schedule: CourseSection[]) => {

--- a/client/src/util/testScheduler.ts
+++ b/client/src/util/testScheduler.ts
@@ -73,7 +73,6 @@ export const filterActivityTypes = (courseSection: CourseSection): boolean => {
  */
 export const filterRestrictedDays = (combinations: CourseSection[][], restrictedDays: string[]): CourseSection[][] => {
     let newCombinations =  combinations.filter((combination: CourseSection[]) => {
-        let validCombination = true;
         for (let section of combination ) {
             const sectionDays: string[] = section["day"].split(" ");
             for (let restrictedDay of sectionDays) {
@@ -112,7 +111,6 @@ export const filterActivityTypesNotLecture = (courseSection: any) => {
     ];
     return !unwantedTypes.some((unwantedType: string) => activity === unwantedType);
 };
-
 
 /**
  * Given an array of unique course sections (lectures), generates all valid combinations


### PR DESCRIPTION
### Changes
- Create `selectedSections` to be stored on redux which is a list of sections selected to must be included in the schedule
- Refactor `addCourse` and `deleteCourse` on redux, merging it as `setCourses`
- Filter a list of schedules to be displayed on `Lectures`
- `ScheduleGrid` now handles the selection of sections

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- To allow users to lock certain sections that they wish to include in their final schedule

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Test locally

### Related Issues
- #121, doesn't close it

### Checklist
- [x] linter
- [x] dependencies
- [x] no additional console errors
