### PR TITLE
Update DB to not insert rows to CoReq/PreReq tables

### DIFF
--- a/server/src/database/setup.ts
+++ b/server/src/database/setup.ts
@@ -24,8 +24,6 @@ export const setupDb = async (update: boolean) => {
 const dropDb = () => db.query(`DROP TABLE IF EXISTS PreReq, CoReq, Course, CourseSection;`);
 
 const createDb = async () => {
-    await db.query(PreReq);
-    await db.query(CoReq);
     await db.query(Course);
 };
 
@@ -39,14 +37,10 @@ const populateDb = () => {
 
         const courses = JSON.parse(data);
         log.info(`${courses.length} courses`);
-        const coReqsToStore: any[] = [];
-        const preReqsToStore: any[] = [];
         const coursesToStore: any[] = [];
         courses.forEach((course: any) => {
             const { courseTitle, courseCode, description, credits, preReqText, coReqText, preReqs = [], coReqs = [], sections = [] } = course;
             const [ courseDept, courseNumber ] = courseCode.split(" ");
-            // coReqs.forEach((coReq: any) => handleReq(courseDept, courseNumber, coReq, coReqText, coReqsToStore));
-            // preReqs.forEach((preReq: any) => handleReq(courseDept, courseNumber, preReq, preReqText, preReqsToStore));
             const sectionJson = JSON.stringify(sections);
             coursesToStore.push([
                 courseTitle, courseDept,
@@ -56,17 +50,9 @@ const populateDb = () => {
             ]);
         });
         try {
-            log.info(`Found ${coReqsToStore.length} co-requisites.`);
-            log.info(`Found ${preReqsToStore.length} pre-requisites.`);
             log.info(`Found ${coursesToStore.length} courses.`);
-            coReqsToStore.forEach(insertCoReq);
-            preReqsToStore.forEach(insertPreReq);
             coursesToStore.forEach(insertCourse);
-            const { rows: coReqs } = await db.query(`SELECT * FROM CoReq`);
-            const { rows: preReqs } = await db.query(`SELECT * FROM PreReq`);
             const { rows: sections } = await db.query(`SELECT * FROM Course`);
-            log.info(`Inserted ${coReqs.length} co-requisites.`);
-            log.info(`Inserted ${preReqs.length} pre-requisites.`);
             log.info(`Inserted ${sections.length} courses.`);
         } catch (e) {
             log.error(`error ${e}`);
@@ -74,17 +60,6 @@ const populateDb = () => {
     });
 };
 
-const handleReq = (courseDept: string, courseNumber: string, req: any, plaintext: string, store: any[]) => {
-    const [reqCourseDept, reqCourseNumber] = req.split(" ");
-    store.push([courseDept, courseNumber, reqCourseDept, reqCourseNumber, plaintext]);
-};
-
-const insertCoReq = (req: []) => insertReq("CoReq", req);
-const insertPreReq = (req: []) => insertReq("PreReq", req);
-
-const insertReq = (table: string, req: []) => {
-    db.query(`INSERT INTO ${table} VALUES ($1, $2, $3, $4, $5)`, req);
-};
 
 const insertCourse = (course: []) => {
     db.query("INSERT INTO Course VALUES ($1, $2, $3, $4, $5, $6, $7, $8)", course);

--- a/server/src/database/setup.ts
+++ b/server/src/database/setup.ts
@@ -45,8 +45,8 @@ const populateDb = () => {
         courses.forEach((course: any) => {
             const { courseTitle, courseCode, description, credits, preReqText, coReqText, preReqs = [], coReqs = [], sections = [] } = course;
             const [ courseDept, courseNumber ] = courseCode.split(" ");
-            coReqs.forEach((coReq: any) => handleReq(courseDept, courseNumber, coReq, coReqText, coReqsToStore));
-            preReqs.forEach((preReq: any) => handleReq(courseDept, courseNumber, preReq, preReqText, preReqsToStore));
+            // coReqs.forEach((coReq: any) => handleReq(courseDept, courseNumber, coReq, coReqText, coReqsToStore));
+            // preReqs.forEach((preReq: any) => handleReq(courseDept, courseNumber, preReq, preReqText, preReqsToStore));
             const sectionJson = JSON.stringify(sections);
             coursesToStore.push([
                 courseTitle, courseDept,

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,10 +1,8 @@
 import express from "express";
-import prereq from "./prereq";
 import course from "./course";
 
 const router = express.Router();
 
-router.use("/api", prereq);
 router.use("/api", course);
 
 export default router;


### PR DESCRIPTION
# Changes
- Commented out code that inserts rows into PreReq/CoReq Tables

## Motivation and Context
- Currently still have too many rows for free tier of Heroku (13k rows), this reduces that number to just over 6k rows
- Production was found to have 0 rows recently (somehow got removed), outlined in #142, this may be due to us having too many rows for free tier, had to repopulate database
- Frees up some database space if we want to save schedules as links in the future

## How Has This Been Tested?
- locally 

## Screenshots (if appropriate):
![unnecessaryTables](https://user-images.githubusercontent.com/42220961/109864368-9755b280-7c17-11eb-851c-03d583a78e0d.png)


# Related Issues
- #142 - doesn't close it yet as we need to figure out if it was the scraper that caused the database to become empty, will do some production scraper testing once this is merged

# Checklist

