### PR TITLE
Update courses in db to summer 2021

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,7 +13,7 @@ const expressLogger = expressPino(log);
 const PORT = process.env.PORT || 5000;
 // asterisks in order are: minute hour day-of-month month day-of-week
 // the below means that the script runs at 12 am every 1st of the month
-const crontab = "33 21 5 * *";
+const crontab = "0 0 1 * *";
 
 const app = express();
 app.use(cors());

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,15 +28,15 @@ app.use((req, res, next) => {
 app.use(expressLogger);
 app.use("/", baseRouter);
 
-cron.schedule(crontab, () => {
-    scraper().then(() => {
-        log.info("Updating database.");
-        setupDb(true);
-    });
-}, {
-    scheduled: true,
-    timezone: "America/Los_Angeles"
-});
+// cron.schedule(crontab, () => {
+//     scraper().then(() => {
+//         log.info("Updating database.");
+//         setupDb(true);
+//     });
+// }, {
+//     scheduled: true,
+//     timezone: "America/Los_Angeles"
+// });
 
 app.listen(PORT, () => {
     log.info(`Server running on port ${PORT}`);

--- a/server/utils/scraper.ts
+++ b/server/utils/scraper.ts
@@ -269,6 +269,7 @@ let formatSectionInfo = async (elmHandle: ElementHandle, browser: Browser): Prom
  * @param {Page} page The Page to be configured
  */
 let pageConfig = async (page: Page) => {
+    await page.setDefaultNavigationTimeout(0);
     await page.setRequestInterception(true);
     page.on("request", (req) => {
         if (req.resourceType() === "image" ||


### PR DESCRIPTION
# Changes
- Updated courses to summer 2021 locally
- Added `page.setDefaultNavigationTimeout(0);` to prevent timeouts when scraping

## Motivation and Context
Courses are outdated in production

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):

# Related Issues
- Closes issue #153 

# Checklist

